### PR TITLE
Fix the link in the development server output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,7 +106,7 @@ const config = {
 
     devServer: {
         contentBase: buildPath,
-        host: '0.0.0.0',
+        host: 'localhost',
         port: 8080
     }
 };


### PR DESCRIPTION
The link:
i ｢wds｣: Project is running at http://0.0.0.0:8080/
does not work in my browser (chrome).
My fix changes the webpack dev server host to "localhost".
